### PR TITLE
Add Hello World REST endpoint

### DIFF
--- a/src/main/java/com/ec2demo/ec2demo/HelloController.java
+++ b/src/main/java/com/ec2demo/ec2demo/HelloController.java
@@ -1,0 +1,13 @@
+package com.ec2demo.ec2demo;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class HelloController {
+
+        @GetMapping("/hello")
+        public String hello() {
+                return "Hello World";
+        }
+}

--- a/src/test/java/com/ec2demo/ec2demo/HelloControllerTest.java
+++ b/src/test/java/com/ec2demo/ec2demo/HelloControllerTest.java
@@ -1,0 +1,24 @@
+package com.ec2demo.ec2demo;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(HelloController.class)
+class HelloControllerTest {
+
+        @Autowired
+        private MockMvc mockMvc;
+
+        @Test
+        void helloEndpointReturnsGreeting() throws Exception {
+                mockMvc.perform(get("/hello"))
+                                .andExpect(status().isOk())
+                                .andExpect(content().string("Hello World"));
+        }
+}


### PR DESCRIPTION
## Summary
- add HelloController with `/hello` mapping returning `Hello World`
- add WebMvcTest for greeting endpoint

## Testing
- `gradle test` *(fails: Plugin [id: 'org.springframework.boot', version: '3.5.4'] was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a019aa1398832f8d5bcdbe78e1f8ea