### PR TITLE
Build amd64 images on ARM builders

### DIFF
--- a/buildspec-docker.yml
+++ b/buildspec-docker.yml
@@ -16,10 +16,14 @@ phases:
   build:
     commands:
       - echo Build JAR & Docker image
-      # If your EC2 is x86, make sure you push an amd64 image from Mac builders; on CodeBuild x86 you can keep plain build
-      # - docker buildx create --use --name multi || docker buildx use multi
-      # - docker buildx build --platform linux/amd64 -t ${IMAGE_REPO_NAME}:${IMAGE_TAG} .
-      - docker build -t ${IMAGE_REPO_NAME}:${IMAGE_TAG} .
+      - |
+          if [ "$(uname -m)" = "arm64" ] || [ "$(uname -m)" = "aarch64" ]; then
+            echo "Detected ARM builder; using buildx for amd64 image"
+            docker buildx create --use --name multi || docker buildx use multi
+            docker buildx build --platform linux/amd64 -t ${IMAGE_REPO_NAME}:${IMAGE_TAG} --load .
+          else
+            docker build -t ${IMAGE_REPO_NAME}:${IMAGE_TAG} .
+          fi
       - docker tag ${IMAGE_REPO_NAME}:${IMAGE_TAG} ${ECR_URI}/${IMAGE_REPO_NAME}:${IMAGE_TAG}
       - docker tag ${IMAGE_REPO_NAME}:${IMAGE_TAG} ${ECR_URI}/${IMAGE_REPO_NAME}:latest
   post_build:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,7 @@ version: "3.9"
 services:
   app:
     image: "${ECR_URI:-ec2-demo-app}:latest"
+    platform: linux/amd64
     build:
       context: .
       dockerfile: Dockerfile


### PR DESCRIPTION
## Summary
- use buildx to build linux/amd64 images when running on ARM builders
- pin docker-compose service to linux/amd64 platform

## Testing
- `gradle test` *(fails: Plugin [id: 'org.springframework.boot', version: '3.5.4'] was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a028c54da0832f8246db66f8e3a2ae